### PR TITLE
Add closeEMOnRollback property on DoctrineEntityManager

### DIFF
--- a/src/Doctrine/DoctrineEntityManager.php
+++ b/src/Doctrine/DoctrineEntityManager.php
@@ -14,15 +14,21 @@ final class DoctrineEntityManager implements Transactional
      * @var EntityManagerInterface
      */
     private $entityManager;
+    /**
+     * @var bool
+     */
+    private $closeEntityManagerOnRollback;
 
     /**
      * Constructor.
      *
      * @param EntityManagerInterface $entityManager
+     * @param bool $closeEntityManagerOnRollback
      */
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $entityManager, $closeEntityManagerOnRollback = false)
     {
         $this->entityManager = $entityManager;
+        $this->closeEntityManagerOnRollback = $closeEntityManagerOnRollback;
     }
 
     /**
@@ -63,6 +69,10 @@ final class DoctrineEntityManager implements Transactional
             $this->entityManager->rollback();
         } catch (\Exception $e) {
             throw new RollbackException('Cannot rollback Doctrine ORM transaction', $e->getCode(), $e);
+        }
+
+        if ($this->closeEntityManagerOnRollback) {
+            $this->entityManager->close();
         }
     }
 }

--- a/tests/spec/Doctrine/DoctrineEntityManagerSpec.php
+++ b/tests/spec/Doctrine/DoctrineEntityManagerSpec.php
@@ -75,4 +75,24 @@ class DoctrineEntityManagerSpec extends ObjectBehavior
         $this->shouldThrow('\RemiSan\TransactionManager\Exception\RollbackException')
              ->duringRollback();
     }
+
+    function it_should_close_em_if_em_transaction_rollback_is_on_closeEntityManagerOnRollback_mode(EntityManagerInterface $entityManager)
+    {
+        $this->beConstructedWith($entityManager, true);
+
+        $entityManager->rollback()->shouldBeCalledTimes(1);
+        $entityManager->close()->shouldBeCalledTimes(1);
+
+        $this->rollback();
+    }
+
+    function it_should_not_close_em_if_em_transaction_rollback_is_not_on_closeEntityManagerOnRollback_mode(EntityManagerInterface $entityManager)
+    {
+        $this->beConstructedWith($entityManager, false);
+
+        $entityManager->rollback()->shouldBeCalledTimes(1);
+        $entityManager->close()->shouldBeCalledTimes(0);
+
+        $this->rollback();
+    }
 }


### PR DESCRIPTION
I need to close the entity manager, if needed, so I can raise a `BeginException` on the next event consuming when trying to begin the transaction and catch it to stop my worker.

I could do it on the Listener/Handler level, but raising a `ConsumerException` at this level does not seem right to me.
