### PR TITLE
fix: improve DoctrineDbalConnectionTransactionManager

### DIFF
--- a/src/Doctrine/DoctrineDbalConnectionTransactionManager.php
+++ b/src/Doctrine/DoctrineDbalConnectionTransactionManager.php
@@ -34,7 +34,7 @@ final class DoctrineDbalConnectionTransactionManager implements Transactional
         try {
             $this->dbalConnection->beginTransaction();
         } catch (\Exception $e) {
-            throw new BeginException('Cannot begin Doctrine DBAL transaction');
+            throw new BeginException('Cannot begin Doctrine DBAL transaction', 0, $e);
         }
     }
 
@@ -46,7 +46,7 @@ final class DoctrineDbalConnectionTransactionManager implements Transactional
         try {
             $this->dbalConnection->commit();
         } catch (ConnectionException $e) {
-            throw new CommitException('Cannot commit Doctrine DBAL transaction');
+            throw new CommitException('Cannot commit Doctrine DBAL transaction', 0, $e);
         }
     }
 
@@ -56,9 +56,9 @@ final class DoctrineDbalConnectionTransactionManager implements Transactional
     public function rollback()
     {
         try {
-            $this->dbalConnection->commit();
+            $this->dbalConnection->rollBack();
         } catch (ConnectionException $e) {
-            throw new RollbackException('Cannot rollback Doctrine DBAL transaction');
+            throw new RollbackException('Cannot rollback Doctrine DBAL transaction', 0, $e);
         }
     }
 }

--- a/tests/spec/Doctrine/DoctrineDbalConnectionTransactionManagerSpec.php
+++ b/tests/spec/Doctrine/DoctrineDbalConnectionTransactionManagerSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace spec\RemiSan\TransactionManager\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ConnectionException;
+use PhpSpec\ObjectBehavior;
+use RemiSan\TransactionManager\Doctrine\DoctrineDbalConnectionTransactionManager;
+use RemiSan\TransactionManager\Exception\BeginException;
+use RemiSan\TransactionManager\Exception\CommitException;
+use RemiSan\TransactionManager\Exception\RollbackException;
+
+class DoctrineDbalConnectionTransactionManagerSpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(DoctrineDbalConnectionTransactionManager::class);
+    }
+
+    function it_should_begin_the_dbal_transaction(Connection $connection)
+    {
+        $connection->beginTransaction();
+
+        $this->beginTransaction();
+    }
+
+    function it_should_throw_an_exception_if_dbal_transaction_begin_failed(Connection $connection)
+    {
+        $connection->beginTransaction()->willThrow(new \Exception());
+
+        $this->shouldThrow(BeginException::class)
+            ->duringBeginTransaction();
+    }
+
+    function it_should_commit_the_dbal_transaction(Connection $connection)
+    {
+        $connection->commit();
+
+        $this->commit();
+    }
+
+    function it_should_throw_an_exception_if_dbal_transaction_commit_failed(Connection $connection)
+    {
+        $connection->commit()->willThrow(ConnectionException::class);
+
+        $this->shouldThrow(CommitException::class)
+            ->duringCommit();
+    }
+
+    function it_should_rollback_the_dbal_transaction(Connection $connection)
+    {
+        $connection->rollBack();
+
+        $this->rollback();
+    }
+
+    function it_should_throw_an_exception_if_dbal_transaction_rollback_failed(Connection $connection)
+    {
+        $connection->rollBack()->willThrow(ConnectionException::class);
+
+        $this->shouldThrow(RollbackException::class)
+            ->duringRollback();
+    }
+
+}


### PR DESCRIPTION
Fix that rollback was trying to call commit instead of rollback on the connection
Add previous exception on thrown exception
Add tests